### PR TITLE
fix: support empty test suites, write paths relative to outputDirectory

### DIFF
--- a/src/jest-sonar.js
+++ b/src/jest-sonar.js
@@ -13,17 +13,11 @@ class JestSonar {
         this.options = this.getOptions(options);
     }
 
-    onTestResult(contexts, info, results) {
-        const rootDir =
-            contexts.context.config.cwd || this.config.rootDir || '';
-        const reporter = new Reporter(rootDir);
-        this.report = reporter.toSonarReport(results);
-    }
-
-    onRunComplete() {
+    onRunComplete(contexts, results) {
+        const reporter = new Reporter(this.config.rootDir || '');
         const fileName = this.getFileName();
         this.createDirectory(path.dirname(fileName));
-        fs.writeFileSync(fileName, this.report, 'utf8');
+        fs.writeFileSync(fileName, reporter.toSonarReport(results), 'utf8');
     }
 
     getFileName() {


### PR DESCRIPTION
This change moves the `.toSonarReport` call to happen in the `onRunComplete` hook instead of `onTestResult`. Currently I have a subproject where I call `jest --passWithNoTests`, but since no test suites are run, this reporter ends up calling `fs.writeFileSync(fileName, undefined, 'utf8').

I also had to change rootDir calculation since `contexts.context.config` isn't available in `onRunComplete`, but if there's a special reason for using it, let me know.