### PR TITLE
fix(#31): fixes #31 issue with null duration

### DIFF
--- a/__test__/reporter/__snapshots__/absolute-path-reporter.spec.js.snap
+++ b/__test__/reporter/__snapshots__/absolute-path-reporter.spec.js.snap
@@ -18,7 +18,7 @@ exports[`AbsolutePathReporter When calling toSonarReport should map a test resul
 <testCase name=\\"When doing this should be ok\\" duration=\\"35\\" />
 </file>
 <file path=\\"/the/root/my-skipped-test.spec.js\\">
-<testCase name=\\"Skipped &quot;this test is skipped&quot;\\" duration=\\"10\\">
+<testCase name=\\"Skipped &quot;this test is skipped&quot;\\" duration=\\"0\\">
 <skipped message=\\"Skipped &quot;this test is skipped&quot;\\"/>
 </testCase>
 </file>

--- a/__test__/reporter/__snapshots__/absolute-path-reporter.spec.js.snap
+++ b/__test__/reporter/__snapshots__/absolute-path-reporter.spec.js.snap
@@ -18,6 +18,11 @@ exports[`AbsolutePathReporter When calling toSonarReport should map a test resul
 <testCase name=\\"When doing this should be ok\\" duration=\\"35\\" />
 </file>
 <file path=\\"/the/root/my-skipped-test.spec.js\\">
+<testCase name=\\"Skipped &quot;this test is skipped&quot;\\" duration=\\"10\\">
+<skipped message=\\"Skipped &quot;this test is skipped&quot;\\"/>
+</testCase>
+</file>
+<file path=\\"/the/root/my-skipped-test.spec.js\\">
 <testCase name=\\"Skipped &quot;this test is skipped&quot;\\" duration=\\"0\\">
 <skipped message=\\"Skipped &quot;this test is skipped&quot;\\"/>
 </testCase>

--- a/__test__/reporter/absolute-path-reporter.spec.js
+++ b/__test__/reporter/absolute-path-reporter.spec.js
@@ -66,6 +66,17 @@ describe('AbsolutePathReporter', () => {
                         testResults: [
                             {
                                 fullName: 'Skipped "this test is skipped"',
+                                duration: 10,
+                                failureMessages: [],
+                                status: 'pending'
+                            }
+                        ]
+                    },
+                    {
+                        testFilePath: '/the/root/my-skipped-test.spec.js',
+                        testResults: [
+                            {
+                                fullName: 'Skipped "this test is skipped"',
                                 duration: null,
                                 failureMessages: [],
                                 status: 'pending'

--- a/__test__/reporter/absolute-path-reporter.spec.js
+++ b/__test__/reporter/absolute-path-reporter.spec.js
@@ -66,7 +66,7 @@ describe('AbsolutePathReporter', () => {
                         testResults: [
                             {
                                 fullName: 'Skipped "this test is skipped"',
-                                duration: 10,
+                                duration: null,
                                 failureMessages: [],
                                 status: 'pending'
                             }

--- a/src/reporter/abstract-reporter.js
+++ b/src/reporter/abstract-reporter.js
@@ -11,7 +11,7 @@ class AbstractReporter {
             testCases: testResult.testResults.map(testCase => {
                 return {
                     name: testCase.fullName,
-                    duration: '' + testCase.duration,
+                    duration: `${testCase.duration || 0}`,
                     failures: testCase.failureMessages,
                     status: testCase.status
                 };


### PR DESCRIPTION
When a test is skipped or marked as a todo the duration is reported
as null. This fix defaults a nullish value to 0 to prevent errors
from SonarQube.