### PR TITLE
feat(#36): Respect <rootDir> in outputDirectory

### DIFF
--- a/__test__/jest-sonar.spec.js
+++ b/__test__/jest-sonar.spec.js
@@ -74,6 +74,41 @@ describe('jest-sonar', () => {
         });
     });
 
+    describe('When the output directory contains <rootDir>', () => {
+        it('should be resolved relative to the jest root directory', () => {
+            const testResults = {};
+
+            const jestSonar = JestSonarBuilder.create()
+                .withOptions({
+                    outputDirectory: '<rootDir>/coverage',
+                    outputName: 'test-report.xml'
+                })
+                .withGlobalConfig({
+                    rootDir: coverageBaseDir + 'test-dir'
+                })
+                .build();
+
+            fs.existsSync.mockReturnValue(false);
+
+            jestSonar.onRunComplete({}, testResults);
+
+            const mockReporter = RelativePathReporter.mock.instances[0];
+            mockReporter.toSonarReport.mockReturnValue('report');
+            expect(mockReporter.toSonarReport).toHaveBeenCalledWith(
+                testResults
+            );
+
+            expect(fs.mkdirSync).toHaveBeenLastCalledWith(
+                `${coverageBaseDir}test-dir/coverage/`
+            );
+            expect(fs.writeFileSync).toHaveBeenCalledWith(
+                `${coverageBaseDir}test-dir/coverage/test-report.xml`,
+                undefined,
+                'utf8'
+            );
+        });
+    });
+
     describe('When the coverageDirectory is passed as parameter', () => {
         it('should use those options to generate a report', () => {
             const testResults = {};

--- a/src/jest-sonar.js
+++ b/src/jest-sonar.js
@@ -26,7 +26,10 @@ class JestSonar {
 
     getFileName() {
         return path.resolve(
-            this.options.outputDirectory,
+            this.replaceRootDirInPath(
+                this.config.rootDir,
+                this.options.outputDirectory
+            ),
             this.options.outputName
         );
     }
@@ -56,6 +59,17 @@ class JestSonar {
             }
             return currentPath;
         }, '');
+    }
+
+    replaceRootDirInPath(rootDir, filePath) {
+        if (!filePath || !/^<rootDir>/.test(filePath)) {
+            return filePath;
+        }
+
+        return path.resolve(
+            rootDir,
+            path.normalize('./' + filePath.substring('<rootDir>'.length))
+        );
     }
 }
 


### PR DESCRIPTION
Resolves outputDirectory relative to the jest root directory if it starts with `<rootDir>`. The implementation was inlined from jest-config.