### PR TITLE
docs: fix yarn install issue

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ It converts the generated report into Sonar's [Generic Execution format](https:/
 
 Using yarn:
 ```bash
-$ yarn install -D jest-sonar
+$ yarn add -D jest-sonar
 ```
 
 Using npm:


### PR DESCRIPTION
Fixes 

> the error `install` has been replaced with `add` to add new dependencies. Run "yarn add jest-sonar --dev" instead.