### PR TITLE
Map filePath to source filePath if sourcemap exists

### DIFF
--- a/__test__/reporter/__snapshots__/absolute-path-reporter.spec.js.snap
+++ b/__test__/reporter/__snapshots__/absolute-path-reporter.spec.js.snap
@@ -29,3 +29,11 @@ exports[`AbsolutePathReporter When calling toSonarReport should map a test resul
 </file>
 </testExecutions>"
 `;
+
+exports[`AbsolutePathReporter When calling toSonarReport should map to the source file if a sourcemap was found 1`] = `
+"<testExecutions version=\\"1\\">
+<file path=\\"/the/root/src/my-test/my-test.spec.ts\\">
+<testCase name=\\"When doing this should &quot;be&quot; ok\\" duration=\\"30\\" />
+</file>
+</testExecutions>"
+`;

--- a/__test__/reporter/__snapshots__/relative-path-reporter.spec.js.snap
+++ b/__test__/reporter/__snapshots__/relative-path-reporter.spec.js.snap
@@ -24,3 +24,11 @@ exports[`RelativePathReporter When calling toSonarReport should map a test resul
 </file>
 </testExecutions>"
 `;
+
+exports[`RelativePathReporter When calling toSonarReport should map to the source file if a sourcemap was found 1`] = `
+"<testExecutions version=\\"1\\">
+<file path=\\"src/my-test/my-test.spec.ts\\">
+<testCase name=\\"When doing this should &quot;be&quot; ok\\" duration=\\"30\\" />
+</file>
+</testExecutions>"
+`;

--- a/src/reporter/abstract-reporter.js
+++ b/src/reporter/abstract-reporter.js
@@ -1,4 +1,6 @@
 const escape = require('./escape');
+const fs = require('fs');
+const path = require('path');
 
 class AbstractReporter {
     constructor(rootDir) {
@@ -7,7 +9,7 @@ class AbstractReporter {
 
     toSonarReport(results) {
         const testResults = results.testResults.map(testResult => ({
-            path: this.mapFilePath(testResult.testFilePath),
+            path: this.mapFilePath(this.mapToSource(testResult.testFilePath)),
             testCases: testResult.testResults.map(testCase => {
                 return {
                     name: testCase.fullName,
@@ -19,6 +21,16 @@ class AbstractReporter {
         }));
 
         return this.render(testResults);
+    }
+
+    mapToSource(filePath) {
+        const sourceMapPath = `${filePath}.map`;
+        if (!fs.existsSync(sourceMapPath)) {
+            return filePath;
+        }
+        const sourceMap = JSON.parse(fs.readFileSync(sourceMapPath, 'utf-8'));
+        const sources = sourceMap.sources.map(source => path.resolve(path.dirname(filePath), source));
+        return sources[0];
     }
 
     mapFilePath(filePath) {


### PR DESCRIPTION
This PR implements a lookup for an optional sourcemap file and maps the test filename reported by Jest to the source filename found in the sourcemap. This is useful when Jest works with the compiled JavaScript files instead of using ts-jest to work with the TypeScript sources.

Fixes #70 